### PR TITLE
Add install and remove to opam

### DIFF
--- a/opam
+++ b/opam
@@ -16,11 +16,9 @@ depends: [
 ]
 install: [
   ["cp" "ledit.out" "%{bin}%/ledit"]
-  ["cp" "ledit.1" "%{bin}%/ledit.1"]
 ]
 remove: [
   ["rm" "%{bin}%/ledit"]
-  ["rm" "%{bin}%/ledit.1"]
 ]
 synopsis: "Line editor, a la rlwrap"
 description: """

--- a/opam
+++ b/opam
@@ -14,6 +14,14 @@ depends: [
   "camlp-streams"
   "ocamlfind"
 ]
+install: [
+  ["cp" "ledit.out" "%{bin}%/ledit"]
+  ["cp" "ledit.1" "%{bin}%/ledit.1"]
+]
+remove: [
+  ["rm" "%{bin}%/ledit"]
+  ["rm" "%{bin}%/ledit.1"]
+]
 synopsis: "Line editor, a la rlwrap"
 description: """
 One-line editor written in OCaml. It provides line editing for the


### PR DESCRIPTION
This resolves #6 - with this patch `ledit` is now correctly placed in the binary directory of opam, e.g., `...(some local dir)/_opam/bin/ledit` :)